### PR TITLE
Add note for MacOS user on using the image version 2.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ Unless otherwise agreed, complete the task using either the JavaScript or the Ty
 
 ## Notes
 
+If you use *MacOS* computer to do the asssessment, you may need to update the `docker-compose.yml` `image` with the version 2.0.0 (`clearpointnz/coding-assessment:2.0.0`) which built specifically for `linux/arm64`. Otherwise, for *Linux* and *Windows*, use the default version 1.0.0.
+
 Please note the following general points;
 
 - Avoid excessive use of third party libraries.


### PR DESCRIPTION
It's a known issue happens for Mac users when running the docker compose 

![image](https://user-images.githubusercontent.com/108249457/233260341-38ff5ae0-93bf-4245-adcf-ba07e41b1404.png)

So the fix involves building new docker image targeting specific platform requires for MacOS. 